### PR TITLE
Add hover effect and dark section backgrounds

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -43,8 +43,10 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(0.05 0 0); /* Fundo escuro */
+  --background: #08080d; /* Fundo escuro padrão */
   --foreground: oklch(0.95 0 0); /* Texto claro */
+  --section-a: #08080d;
+  --section-b: #0c0c12;
   --card: oklch(0.1 0 0); /* Cards escuros */
   --card-foreground: oklch(0.95 0 0);
   --popover: oklch(0.1 0 0);
@@ -77,7 +79,7 @@
 }
 
 .dark {
-  --background: oklch(0.05 0 0);
+  --background: #08080d;
   --foreground: oklch(0.95 0 0);
   --card: oklch(0.1 0 0);
   --card-foreground: oklch(0.95 0 0);
@@ -144,10 +146,26 @@
 
 /* Gradientes customizados */
 .gradient-bg {
-  background: linear-gradient(135deg, 
-    oklch(0.05 0 0) 0%, 
-    oklch(0.1 0.05 240) 50%, 
+  background: linear-gradient(135deg,
+    oklch(0.05 0 0) 0%,
+    oklch(0.1 0.05 240) 50%,
     oklch(0.05 0 0) 100%);
+}
+
+.bg-section-a {
+  background-color: var(--section-a);
+}
+
+.bg-section-b {
+  background-color: var(--section-b);
+}
+
+section:nth-of-type(odd):not(.gradient-bg) {
+  background-color: var(--section-a);
+}
+
+section:nth-of-type(even):not(.gradient-bg) {
+  background-color: var(--section-b);
 }
 
 .text-gradient {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -221,7 +221,7 @@ const HeroSection = () => {
 // Componente da Seção Sobre
 const AboutSection = () => {
   return (
-    <section id="sobre" className="py-20 bg-background">
+    <section id="sobre" className="py-20">
       <div className="container mx-auto px-4">
         <motion.div 
           className="text-center mb-16"
@@ -324,7 +324,7 @@ const BenefitsSection = () => {
   ];
 
   return (
-    <section id="beneficios" className="py-20 bg-background">
+    <section id="beneficios" className="py-20">
       <div className="container mx-auto px-4">
         <motion.div 
           className="text-center mb-16"
@@ -532,7 +532,7 @@ const Footer = () => {
 // Componente principal App
 function App() {
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="min-h-screen text-foreground">
       <Header />
       <HeroSection />
       <AboutSection /> {/* Adicionado a seção Sobre */}
@@ -561,7 +561,7 @@ const PartnersSection = () => {
   ];
 
   return (
-    <section id="parceiros" className="py-20 bg-background">
+    <section id="parceiros" className="py-20">
       <div className="container mx-auto px-4 text-center">
         <motion.p
           className="text-primary text-lg font-semibold mb-4"
@@ -595,9 +595,10 @@ const PartnersSection = () => {
           {partners.map((partner, index) => (
             <motion.div
               key={index}
-              className="bg-card p-6 rounded-lg shadow-lg flex flex-col items-center justify-center h-48"
+              className="bg-card p-6 rounded-lg shadow-lg flex flex-col items-center justify-center h-48 transition-transform"
               initial={{ opacity: 0, scale: 0.8 }}
               whileInView={{ opacity: 1, scale: 1 }}
+              whileHover={{ scale: 1.05 }}
               transition={{ duration: 0.5, delay: index * 0.1 }}
               viewport={{ once: true }}
             >
@@ -698,7 +699,7 @@ const GrowthSection = () => {
 // Componente "Pronto para revolucionar seu negócio?"
 const RevolutionSection = () => {
   return (
-    <section id="revolucao" className="py-20 bg-background">
+    <section id="revolucao" className="py-20">
       <div className="container mx-auto px-4 text-center">
         <motion.p
           className="text-primary text-lg font-semibold mb-4"


### PR DESCRIPTION
## Summary
- add hover scale effect to partner cards
- remove hard-coded background class from sections
- alternate section backgrounds via new CSS variables
- set default background color to `#08080d`

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.4.1.tgz)*
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.4.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68805d288c448321bb1fe496cc34ac90