### PR TITLE
Increase CTA WhatsApp button size

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -749,7 +749,7 @@ const RevolutionSection = () => {
           <a href="https://wa.me/5511919235181" target="_blank" rel="noopener noreferrer">
             <Button
               size="lg"
-              className="text-lg px-10 py-4 bg-green-500 text-white hover:bg-green-600 hover:scale-105 transition-transform"
+              className="h-14 px-12 text-lg hover:scale-105 transition-transform"
             >
               <MessageCircle className="w-6 h-6" />
               Solicitar uma proposta


### PR DESCRIPTION
## Summary
- enlarge the WhatsApp call to action button
- use the default button color so it matches the other buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68811dedcacc8321a6bc1d62cab567d6