### PR TITLE
Adjust base fonts and button sizing

### DIFF
--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -5,7 +5,7 @@ import { cva } from "class-variance-authority";
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-base font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
@@ -22,10 +22,10 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        default: "h-10 px-5 py-3 has-[>svg]:px-4",
+        sm: "h-9 rounded-lg gap-1.5 px-4 py-2 has-[>svg]:px-3",
+        lg: "h-12 rounded-lg px-8 has-[>svg]:px-6",
+        icon: "size-10",
       },
     },
     defaultVariants: {

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,6 @@
-html { scroll-behavior: smooth; }
+html {
+  scroll-behavior: smooth;
+  font-size: 18px;
+}
 
 a, button { cursor: pointer; }


### PR DESCRIPTION
## Summary
- increase the root font size so text is slightly larger everywhere
- enlarge default button styles to stand out

## Testing
- `pnpm lint` *(fails: couldn't download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68868d8c22a883219991529f8b4815c7