### PR TITLE
Add animated floating WhatsApp button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -975,13 +975,20 @@ const CookieConsent = () => {
 
 // Botão flutuante do WhatsApp
 const FloatingWhatsApp = () => (
-  <a
+  <motion.a
     href='https://wa.me/5511919235181?text=Gostaria%20de%20fazer%20um%20orcamento.'
     target='_blank'
     rel='noopener noreferrer'
-    className='fixed bottom-6 right-6 bg-green-500 text-white p-4 rounded-full shadow-lg z-50 hover:bg-green-600 transition-colors relative'
+    aria-label='Conversar no WhatsApp'
+    initial={{ y: 80, opacity: 0 }}
+    animate={{ y: 0, opacity: 1 }}
+    whileHover={{ scale: 1.1 }}
+    transition={{ type: "spring", stiffness: 300, damping: 20 }}
+    className='fixed bottom-6 right-6 z-50 flex items-center justify-center'
   >
-    <img src={whatsappIcon} alt='WhatsApp' className='w-6 h-6' />
-    <span className='absolute -top-1 -right-1 bg-red-600 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center'>1</span>
-  </a>
+    <span className='absolute inline-flex h-14 w-14 rounded-full bg-green-500/75 animate-ping'></span>
+    <span className='relative inline-flex h-14 w-14 items-center justify-center rounded-full bg-green-500 text-white shadow-xl'>
+      <img src={whatsappIcon} alt='WhatsApp' className='w-7 h-7' />
+    </span>
+  </motion.a>
 );


### PR DESCRIPTION
## Summary
- add a floating WhatsApp button using framer-motion

## Testing
- `pnpm lint` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_6886997872208321b82804b8bedbdfaf