### PR TITLE
Fix partners card layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -705,7 +705,7 @@ const PartnersSection = () => {
           {partners.map((partner, index) => (
             <motion.div
               key={index}
-              className='bg-card p-6 rounded-lg shadow-lg flex flex-col items-center justify-center h-48 transition-transform'
+              className='bg-card p-6 rounded-lg shadow-lg flex flex-col items-center justify-center aspect-square w-full transition-transform'
               initial={{ opacity: 0, scale: 0.8 }}
               whileInView={{ opacity: 1, scale: 1 }}
               whileHover={{ scale: 1.05 }}


### PR DESCRIPTION
## Summary
- make partner cards square and centered by replacing the fixed height with `aspect-square` and ensuring the width fills the grid cell

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6886a81226c8832183efb7cbd528c65a