### PR TITLE
Fix cookie consent overlay on desktop

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -969,7 +969,7 @@ const CookieConsent = () => {
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 100 }}
       transition={{ duration: 0.5 }}
-      className='fixed bottom-24 md:bottom-4 left-4 right-4 bg-card p-6 rounded-lg shadow-lg flex flex-col md:flex-row items-center justify-between z-50'
+      className='fixed bottom-24 md:bottom-16 left-4 right-4 bg-card p-6 rounded-lg shadow-lg flex flex-col md:flex-row items-center justify-between z-50'
     >
       <p className='text-sm text-muted-foreground mb-4 md:mb-0 md:mr-4'>
         Utilizamos cookies para melhorar sua experiência de navegação e analisar


### PR DESCRIPTION
## Summary
- move the cookie consent banner higher so the WhatsApp button isn't covered on desktop

## Testing
- `pnpm lint` *(fails: can't fetch pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_6886bec24b64832183cb532bde0c8f9d