### PR TITLE
Adjust WhatsApp buttons and styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -204,7 +204,7 @@ section:nth-of-type(even):not(.gradient-bg) {
 
 /* Gradiente do botão do WhatsApp */
 .whatsapp-button {
-  /* Cor sólida para o botão flutuante */
-  background-color: var(--primary);
-  color: var(--primary-foreground);
+  /* Cor sólida para o botão do WhatsApp */
+  background-color: #25d366;
+  color: #fff;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -115,7 +115,11 @@ const Header = () => {
           >
             Benefícios
           </a>
-          <a href='/#revolucao'>
+          <a
+            href='https://wa.me/5511919235181?text=Ol%C3%A1%2C%20tudo%20bem%3F%20Estou%20interessado%28a%29%20em%20fazer%20um%20or%C3%A7amento.%20Poderia%20me%20passar%20as%20informa%C3%A7%C3%B5es%3F'
+            target='_blank'
+            rel='noopener noreferrer'
+          >
             <Button>Solicitar Orçamento</Button>
           </a>
         </nav>
@@ -155,7 +159,11 @@ const Header = () => {
               >
                 Benefícios
               </a>
-              <a href='/#revolucao'>
+              <a
+                href='https://wa.me/5511919235181?text=Ol%C3%A1%2C%20tudo%20bem%3F%20Estou%20interessado%28a%29%20em%20fazer%20um%20or%C3%A7amento.%20Poderia%20me%20passar%20as%20informa%C3%A7%C3%B5es%3F'
+                target='_blank'
+                rel='noopener noreferrer'
+              >
                 <Button className='w-full'>Solicitar Orçamento</Button>
               </a>
             </nav>

--- a/src/Terms.jsx
+++ b/src/Terms.jsx
@@ -118,7 +118,7 @@ const CookieConsent = () => {
 
 const FloatingWhatsApp = () => (
   <a
-    href='https://wa.me/5511919235181?text=Gostaria%20de%20fazer%20um%20orcamento.'
+    href='https://wa.me/5511919235181?text=Ol%C3%A1%2C%20tudo%20bem%3F%20Estou%20interessado%28a%29%20em%20fazer%20um%20or%C3%A7amento.%20Poderia%20me%20passar%20as%20informa%C3%A7%C3%B5es%3F'
     target='_blank'
     rel='noopener noreferrer'
     aria-label='Conversar no WhatsApp'


### PR DESCRIPTION
## Summary
- update the floating WhatsApp button message in `Terms.jsx`
- make the floating WhatsApp button green with white icon
- link "Solicitar Orçamento" buttons directly to WhatsApp with the same message

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6886e0c558248321aeac10c678bec207